### PR TITLE
Simplify Rust example a bit.

### DIFF
--- a/things/index.html
+++ b/things/index.html
@@ -476,7 +476,7 @@ use std::sync::{Arc, RwLock, Weak};
 use uuid::Uuid;
 use webthing::{Action, BaseAction, BaseEvent, BaseProperty, BaseThing, Event, Thing,
                WebThingServer};
-use webthing::property::ValueForwarder;
+use webthing::property::EmptyValueForwarder;
 use webthing::server::ActionGenerator;
 
 pub struct OverheatedEvent(BaseEvent);
@@ -618,14 +618,6 @@ impl ActionGenerator for Generator {
             "fade" =&gt; Some(Box::new(FadeAction::new(input, thing))),
             _ =&gt; None,
         }
-    }
-}
-
-struct EmptyValueForwarder;
-
-impl ValueForwarder for EmptyValueForwarder {
-    fn set_value(&amp;mut self, value: serde_json::Value) -&gt; Result&lt;serde_json::Value, &amp;'static str&gt; {
-        Ok(value)
     }
 }
 


### PR DESCRIPTION
This is to stay in sync with the webthing-rust library's example.