### PR TITLE
Add missing Gemfile for Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "jekyll"
+gem "jekyll", "~> 3.7"
+gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+include:
+  - _redirects

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/docs/*		http://docs.iot.mozilla.org/:splat	200

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /docs/*		http://docs.iot.mozilla.org/:splat	200
+/schemas/*	http://schemas.iot.mozilla.org/:splat	200

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,3 @@
 /docs/*		http://docs.iot.mozilla.org/:splat	200
 /schemas/*	http://schemas.iot.mozilla.org/:splat	200
+/wot/*		http://wot.iot.mozilla.org/:splat	200

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
-/docs/*		http://docs.iot.mozilla.org/:splat	200
-/schemas/*	http://schemas.iot.mozilla.org/:splat	200
-/wot/*		http://wot.iot.mozilla.org/:splat	200
+/docs/*		https://docs.iot.mozilla.org/:splat	200
+/schemas/*	https://schemas.iot.mozilla.org/:splat	200
+/wot/*		https://wot.iot.mozilla.org/:splat	200


### PR DESCRIPTION
This is so that our upcoming automation can build this site correctly.

Also included is a redirect manifest for the sub-sites, also needed.