### PR TITLE
Redirect /schema et al without splats as well

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,6 @@
 /docs/*		https://docs.iot.mozilla.org/:splat	200
+/docs		https://docs.iot.mozilla.org/ 200
 /schemas/*	https://schemas.iot.mozilla.org/:splat	200
+/schemas https://schemas.iot.mozilla.org/ 200
 /wot/*		https://wot.iot.mozilla.org/:splat	200
+/wot		https://wot.iot.mozilla.org/	200


### PR DESCRIPTION
To try to fix bug https://bugzilla.mozilla.org/show_bug.cgi?id=1601050